### PR TITLE
Setup on Windows 11 fixed

### DIFF
--- a/src/pkgmt/dev.py
+++ b/src/pkgmt/dev.py
@@ -82,7 +82,7 @@ def setup(c, version=None, doc=False):
 
     r = c.run(
         f"{conda_hook} && conda activate {env_name} && "
-        f"python -c 'import {pkg_name}; print({pkg_name})'"
+        f'python -c "import {pkg_name}; print({pkg_name})"'
     )
 
     if "site-packages" in r.stdout:


### PR DESCRIPTION
original issue : [jupysql_#301](https://github.com/ploomber/jupysql/issues/301)

Syntax changed from `"python -c 'import {pkg_name}; print({pkg_name})'"` to `'python -c "import {pkg_name}; print({pkg_name})"'` so it can run on PowerShell

cc: @edublancas 