### PR TITLE
Fixed override issue when using `pyproject.toml`

### DIFF
--- a/src/pkgmt/formatting.py
+++ b/src/pkgmt/formatting.py
@@ -2,6 +2,7 @@ from pathlib import Path
 import sys
 import subprocess
 import click
+import toml
 
 try:
     import jupytext
@@ -36,7 +37,24 @@ def find_root():
 def format(exclude):
     current = find_root()
 
+    if Path("pyproject.toml").exists():
+        with open("pyproject.toml") as f:
+            data = toml.load(f)
+
+        if "tool" in data and "black" in data["tool"]:
+            exclude_pyproj = data["tool"]["black"].get("extend-exclude", "")
+        else:
+            exclude_pyproj = ""
+    else:
+        exclude_pyproj = ""
+
     exclude_str = "|".join(exclude)
+
+    if exclude_pyproj:
+        if exclude_str:
+            exclude_str += "|" + exclude_pyproj
+        else:
+            exclude_str = exclude_pyproj
 
     cmd = ["black", ".", "--extend-exclude", exclude_str]
     click.echo("Running command:" + " ".join(map(quote, cmd)))

--- a/src/pkgmt/hook.py
+++ b/src/pkgmt/hook.py
@@ -4,6 +4,7 @@ import click
 import shutil
 import sys
 import subprocess
+import toml
 
 try:
     import jupytext
@@ -65,8 +66,25 @@ def _lint(files=None, exclude=None):
     else:
         files = list(files)
 
+    if Path("pyproject.toml").exists():
+        with open("pyproject.toml") as f:
+            data = toml.load(f)
+
+        if "tool" in data and "black" in data["tool"]:
+            exclude_pyproj = data["tool"]["black"].get("extend-exclude", "")
+        else:
+            exclude_pyproj = ""
+    else:
+        exclude_pyproj = ""
+
     exclude_str_flake8 = ",".join(exclude)
     exclude_str_black = "|".join(exclude)
+
+    if exclude_pyproj:
+        if exclude_str_black:
+            exclude_str_black += "|" + exclude_pyproj
+        else:
+            exclude_str_black = exclude_pyproj
 
     cmd_black = ["black", "--check"] + files + ["--extend-exclude", exclude_str_black]
     cmd_flake8 = ["flake8"] + files + ["--extend-exclude", exclude_str_flake8]


### PR DESCRIPTION
Closes #66 

Added a `pyproject.toml` parser to black in both `format` and `lint` to pass the arguments to `--extend-exclude`