### PR TITLE
clearer error message in `pkgmt version`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [API Change] Support for projects containing `version` key in `pyproject.toml`. ([#58](https://github.com/ploomber/pkgmt/issues/58))
 * [Fix] Fix bug when running git hook
+* [Fix] Proper error message when version file is empty, or version string not found. Display version file location when inconsistent version in changelog (#64)
 
 ## 0.6.2 (2023-06-30)
 

--- a/src/pkgmt/changelog.py
+++ b/src/pkgmt/changelog.py
@@ -190,6 +190,7 @@ class CHANGELOG:
         self.tree = markdown(text)
 
         versioner = Versioner(project_root=project_root)
+        self.version_file = versioner.get_version_file_path()
         self.current = versioner.current_version()
 
     @classmethod
@@ -290,7 +291,7 @@ class CHANGELOG:
             raise ProjectValidationError(
                 "[Inconsistent version] Version in  top section in "
                 f"CHANGELOG is {subheading!r}, "
-                f"but version in __init__.py is {self.current!r}, "
+                f"but version in {self.version_file} is {self.current!r}, "
                 "fix them so they match"
             )
 

--- a/src/pkgmt/versioner/versioner.py
+++ b/src/pkgmt/versioner/versioner.py
@@ -5,6 +5,8 @@ import subprocess
 
 from pathlib import Path
 
+import click
+
 from pkgmt.versioner.util import complete_version_string, find_package_and_version_file
 
 
@@ -51,14 +53,32 @@ class Versioner:
             self.path_to_changelog = None
         self.version_file = version_file_name
 
+    def get_version_file_path(self):
+        """Returns the version file path from project root"""
+        return str(self.PACKAGE / self.version_file)
+
     def current_version(self):
         """Returns the current version in version file"""
         _version_re = re.compile(r"__version__\s+=\s+(.*)")
 
         with open(self.PACKAGE / self.version_file, "rb") as f:
-            VERSION = str(
-                ast.literal_eval(_version_re.search(f.read().decode("utf-8")).group(1))
-            )
+            try:
+                VERSION = str(
+                    ast.literal_eval(
+                        _version_re.search(f.read().decode("utf-8")).group(1)
+                    )
+                )
+            except AttributeError:
+                raise click.ClickException(
+                    f"Please add version string in "
+                    f"{self.get_version_file_path()}, e.g., __version__ = '0.1dev'"
+                )
+            except SyntaxError:
+                raise click.ClickException(
+                    f"Could not find __version__ value in "
+                    f"{self.get_version_file_path()}. Please add in the format"
+                    f" __version__ = '0.1dev'"
+                )
 
         return VERSION
 


### PR DESCRIPTION
Error message improvements:
1. Clearer error message when version file empty/ version not found
2. Version file path included in error when changelog version is inconsistent with version file

Closes #64 
