### PR TITLE
config validations and adding tag,push keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## 0.7.1 (2023-07-14)
 
 * [Fix] Fixed `black` `--extend-exclude` override in `pyproject.toml`([#66](https://github.com/ploomber/pkgmt/issues/66))
-* [Fix] Validations of keys in `pyproject.toml` (#65)
+* [Fix] Validation of keys in `pyproject.toml` (#65)
 * [Feature] Added `push` and `tag` versioner configuration keys (#63)
 
 ## 0.7.0 (2023-07-11)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ## 0.7.1 (2023-07-14)
 
 * [Fix] Fixed `black` `--extend-exclude` override in `pyproject.toml`([#66](https://github.com/ploomber/pkgmt/issues/66))
+* [Fix] Validations of keys in `pyproject.toml` (#65)
+* [Feature] Added `push` and `tag` versioner configuration keys (#63)
 
 ## 0.7.0 (2023-07-11)
 

--- a/doc/versioner.md
+++ b/doc/versioner.md
@@ -77,6 +77,13 @@ The `version` key in the `pyproject.toml` file can be used to specify the follow
 * `tag`: Specifies whether to tag the commit with the stable version. Available options: `true` / `false`.
 * `push` : Specifies whether to push the changes to the remote repository. Available options: `true` / `false`.
 
+Example:
+
+```
+[tool.pkgmt]
+github = "project/repository" 
+version = {version_file = "/path/to/version_file.py", tag=true, push=false}
+```
 Note that these configurations are optional. If passed, the options override the default values. Default value of `push` and `tag` is `True.
 
 ### New version

--- a/doc/versioner.md
+++ b/doc/versioner.md
@@ -77,7 +77,7 @@ The `version` key in the `pyproject.toml` file can be used to specify the follow
 * `tag`: Specifies whether to tag the commit with the stable version. Available options: `true` / `false`.
 * `push` : Specifies whether to push the changes to the remote repository. Available options: `true` / `false`.
 
-Note that `tag` and `push` are optional. If passed, the options override the default value of `True`.
+Note that these configurations are optional. If passed, the options override the default values. Default value of `push` and `tag` is `True.
 
 ### New version
 

--- a/doc/versioner.md
+++ b/doc/versioner.md
@@ -69,6 +69,15 @@ github = "project/repository"
 version = {version_file = 'app_two/__init__.py'}
 ```
 
+#### Version in pyproject.toml
+
+The `version` key in the `pyproject.toml` file can be used to specify the following:
+
+* `version_file` : path of the file in which the `__version__` string is specified.
+* `tag`: Specifies whether to tag the commit with the stable version. Available options: `true` / `false`.
+* `push` : Specifies whether to push the changes to the remote repository. Available options: `true` / `false`.
+
+Note that `tag` and `push` are optional. If passed, the options override the default value of `True`.
 
 ### New version
 

--- a/src/pkgmt/changelog.py
+++ b/src/pkgmt/changelog.py
@@ -73,7 +73,7 @@ def _replace_handles_with_links(text):
 
 def _expand_github_from_text(text):
     """Convert strings with the #{number} format into their"""
-    cfg = config.load()
+    cfg = config.PyprojectConfig().get_config()
     url = f'https://github.com/{cfg["github"]}/issues/'
     return _replace_handles_with_links(_replace_issue_number_with_links(url, text))
 

--- a/src/pkgmt/changelog.py
+++ b/src/pkgmt/changelog.py
@@ -73,7 +73,7 @@ def _replace_handles_with_links(text):
 
 def _expand_github_from_text(text):
     """Convert strings with the #{number} format into their"""
-    cfg = config.PyprojectConfig().get_config()
+    cfg = config.Config.from_file("pyproject.toml")
     url = f'https://github.com/{cfg["github"]}/issues/'
     return _replace_handles_with_links(_replace_issue_number_with_links(url, text))
 

--- a/src/pkgmt/cli.py
+++ b/src/pkgmt/cli.py
@@ -9,7 +9,6 @@ from pkgmt import links, config, test, changelog, hook as hook_, versioneer
 from pkgmt import new as new_
 from pkgmt import dev
 from pkgmt import formatting
-from pkgmt.config import load
 
 
 @click.group()
@@ -28,7 +27,7 @@ def check_links(only_404):
     """Check for broken links"""
     broken_http_codes = None if not only_404 else [404]
 
-    cfg = config.load()["check_links"]
+    cfg = config.PyprojectConfig().get_config()["check_links"]
     out = links.find_broken_in_files(
         cfg["extensions"],
         cfg.get("ignore_substrings"),
@@ -101,8 +100,8 @@ def hook(uninstall, run):
 @click.option("--target", default=None)
 def version(yes, push, tag, target):
     """Create a new package version"""
-    cfg = load()
-    cfg_tag, cfg_push = config.read_version_configurations(cfg)
+
+    cfg_tag, cfg_push = config.PyprojectConfig().get_version_configurations()
 
     if tag is not None:
         if cfg_tag is not None and tag != cfg_tag:

--- a/src/pkgmt/cli.py
+++ b/src/pkgmt/cli.py
@@ -27,7 +27,7 @@ def check_links(only_404):
     """Check for broken links"""
     broken_http_codes = None if not only_404 else [404]
 
-    cfg = config.PyprojectConfig().get_config()["check_links"]
+    cfg = config.Config.from_file("pyproject.toml")["check_links"]
     out = links.find_broken_in_files(
         cfg["extensions"],
         cfg.get("ignore_substrings"),
@@ -101,27 +101,15 @@ def hook(uninstall, run):
 def version(yes, push, tag, target):
     """Create a new package version"""
 
-    cfg_tag, cfg_push = config.PyprojectConfig().get_version_configurations()
+    cfg = config.Config.from_file("pyproject.toml", cli_args=dict(push=push, tag=tag))
 
-    if tag is not None:
-        if cfg_tag is not None and tag != cfg_tag:
-            print(
-                f"Value of 'tag' from CLI : {tag}. "
-                f"This will override tag={cfg_tag} as configured in pyproject.toml"
-            )
-    else:
-        tag = cfg_tag if cfg_tag is not None else True
-
-    if push is not None:
-        if cfg_push is not None and push != cfg_push:
-            print(
-                f"Value of 'push' from CLI : {push}. "
-                f"This will override push={cfg_push} as configured in pyproject.toml"
-            )
-    else:
-        push = cfg_push if cfg_push is not None else True
-
-    versioneer.version(project_root=".", tag=tag, yes=yes, push=push, target=target)
+    versioneer.version(
+        project_root=".",
+        tag=cfg["version"]["tag"],
+        yes=yes,
+        push=cfg["version"]["push"],
+        target=target,
+    )
 
 
 @cli.command()

--- a/src/pkgmt/cli.py
+++ b/src/pkgmt/cli.py
@@ -9,6 +9,7 @@ from pkgmt import links, config, test, changelog, hook as hook_, versioneer
 from pkgmt import new as new_
 from pkgmt import dev
 from pkgmt import formatting
+from pkgmt.config import load
 
 
 @click.group()
@@ -95,11 +96,32 @@ def hook(uninstall, run):
     default=False,
     help="Do not ask for confirmation",
 )
-@click.option("--push/--no-push", default=True)
-@click.option("--tag/--no-tag", default=True)
+@click.option("--push/--no-push", default=None)
+@click.option("--tag/--no-tag", default=None)
 @click.option("--target", default=None)
 def version(yes, push, tag, target):
     """Create a new package version"""
+    cfg = load()
+    cfg_tag, cfg_push = config.read_version_configurations(cfg)
+
+    if tag is not None:
+        if cfg_tag is not None and tag != cfg_tag:
+            print(
+                f"Value of 'tag' from CLI : {tag}. "
+                f"This will override tag={cfg_tag} as configured in pyproject.toml"
+            )
+    else:
+        tag = cfg_tag if cfg_tag is not None else True
+
+    if push is not None:
+        if cfg_push is not None and push != cfg_push:
+            print(
+                f"Value of 'push' from CLI : {push}. "
+                f"This will override push={cfg_push} as configured in pyproject.toml"
+            )
+    else:
+        push = cfg_push if cfg_push is not None else True
+
     versioneer.version(project_root=".", tag=tag, yes=yes, push=push, target=target)
 
 

--- a/src/pkgmt/config.py
+++ b/src/pkgmt/config.py
@@ -28,8 +28,15 @@ class Config(Mapping):
 
 def load():
     if Path("pyproject.toml").exists():
-        with open("pyproject.toml") as f:
-            return Config(toml.load(f)["tool"]["pkgmt"], "pyproject.toml")
+        try:
+            with open("pyproject.toml") as f:
+                return Config(toml.load(f)["tool"]["pkgmt"], "pyproject.toml")
+        except toml.decoder.TomlDecodeError as e:
+            raise ValueError(
+                f"Invalid pyproject.toml file: {e}."
+                "If using a boolean "
+                "value ensure it's in lowercase, e.g., key = true"
+            )
     else:
         raise FileNotFoundError(
             "Could not load configuration file: expected a pyproject.toml file"

--- a/src/pkgmt/config.py
+++ b/src/pkgmt/config.py
@@ -142,14 +142,20 @@ class Config(Mapping):
                     data = Config._resolve_version_configuration(
                         data, kwargs.get("cli_args")
                     )
-                    return cls(data, "pyproject.toml")
+                    return cls(data, file)
             except toml.decoder.TomlDecodeError as e:
                 raise InvalidConfiguration(
-                    f"Invalid pyproject.toml file: {str(e)}."
+                    f"Invalid {file} file: {str(e)}."
                     "If using a boolean "
                     "value ensure it's in lowercase, e.g., key = true"
                 ) from e
+            except KeyError as e:
+                raise InvalidConfiguration(
+                    f"Missing key : {str(e)}.\n{file} "
+                    f"should contain 'tool.pkgmt' key."
+                ) from e
+
         else:
             raise FileNotFoundError(
-                "Could not load configuration file: expected a pyproject.toml file"
+                f"Could not load configuration file: expected a {file} file"
             )

--- a/src/pkgmt/config.py
+++ b/src/pkgmt/config.py
@@ -2,6 +2,10 @@ from collections.abc import Mapping
 
 import toml
 from pathlib import Path
+from pkgmt.exceptions import InvalidConfiguration
+
+VALID_KEYS = ["github", "version", "package_name", "check_links"]
+VALID_VERSION_KEYS = ["version_file", "tag", "push"]
 
 
 class Config(Mapping):
@@ -26,13 +30,64 @@ class Config(Mapping):
         return f"{type(self).__name__}({self._data!r})"
 
 
+def validate_config(cfg):
+    """
+    Function to validate top level and version keys in
+    config file.
+    """
+    keys = list(cfg.keys())
+    for key in keys:
+        if key not in VALID_KEYS:
+            raise InvalidConfiguration(
+                f"Invalid key '{key}' in"
+                f" pyproject.toml file. Valid keys are : "
+                f"{', '.join(VALID_KEYS)}"
+            )
+
+        if cfg.get("version", {}):
+            version_keys = list(cfg.get("version").keys())
+            for key in version_keys:
+                if key not in VALID_VERSION_KEYS:
+                    raise InvalidConfiguration(
+                        f"Invalid version key '{key}' in"
+                        f" pyproject.toml file. Valid keys are : "
+                        f"{', '.join(VALID_VERSION_KEYS)}"
+                    )
+
+
+def read_version_configurations(cfg):
+    """
+    Function to return tag and push from
+    pyproject.toml if provided by user.
+    Example file:
+    [tool.pkgmt]
+    github = "repository/package"
+    version = {version_file = "/app/_version.py", tag=True, push=False}
+    """
+    tag = cfg.get("version", {}).get("tag", None)
+    push = cfg.get("version", {}).get("push", None)
+    if tag is not None and not isinstance(tag, bool):
+        raise InvalidConfiguration(
+            "Type of 'tag' key in pyproject.toml is invalid. "
+            "It should be lowercase boolean : true / false"
+        )
+    if push is not None and not isinstance(push, bool):
+        raise InvalidConfiguration(
+            "Type of 'push' key in pyproject.toml is invalid. "
+            "It should be lowercase boolean : true / false"
+        )
+    return tag, push
+
+
 def load():
     if Path("pyproject.toml").exists():
         try:
             with open("pyproject.toml") as f:
-                return Config(toml.load(f)["tool"]["pkgmt"], "pyproject.toml")
+                cfg = Config(toml.load(f)["tool"]["pkgmt"], "pyproject.toml")
+                validate_config(cfg)
+                return cfg
         except toml.decoder.TomlDecodeError as e:
-            raise ValueError(
+            raise InvalidConfiguration(
                 f"Invalid pyproject.toml file: {str(e)}."
                 "If using a boolean "
                 "value ensure it's in lowercase, e.g., key = true"

--- a/src/pkgmt/config.py
+++ b/src/pkgmt/config.py
@@ -1,6 +1,7 @@
 from collections.abc import Mapping
 
 import toml
+import click
 from pathlib import Path
 from pkgmt.exceptions import InvalidConfiguration
 
@@ -29,15 +30,131 @@ class Config(Mapping):
     def __repr__(self) -> str:
         return f"{type(self).__name__}({self._data!r})"
 
+    @staticmethod
+    def _validate_config(data):
+        """
+        Function to validate top level and version keys in
+        config file.
+        """
 
-class PyprojectConfig:
-    def __init__(self):
-        self.cfg = None
-        if Path("pyproject.toml").exists():
+        top_level_keys = list(data)
+        invalid_top_level_keys = [
+            key for key in top_level_keys if key not in VALID_KEYS
+        ]
+        if invalid_top_level_keys:
+            raise InvalidConfiguration(
+                f"Invalid keys in pyproject.toml file: "
+                f"{', '.join(invalid_top_level_keys)}. "
+                f"Valid keys are: {', '.join(VALID_KEYS)}"
+            )
+
+        version_data = data.get("version", {})
+        version_keys = list(version_data)
+
+        invalid_version_keys = [
+            key for key in version_keys if key not in VALID_VERSION_KEYS
+        ]
+        if invalid_version_keys:
+            raise InvalidConfiguration(
+                f"Invalid version keys in pyproject.toml "
+                f"file: {', '.join(invalid_version_keys)}. "
+                f"Valid version keys are: {', '.join(VALID_VERSION_KEYS)}"
+            )
+
+    @staticmethod
+    def _validate_boolean_key(keys, values):
+        if not isinstance(keys, list):
+            keys = [keys]
+        if not isinstance(values, list):
+            values = [values]
+
+        if len(keys) != len(values):
+            raise ValueError("Keys and values lists must have the same length")
+
+        invalid_keys = [
+            key
+            for key, value in zip(keys, values)
+            if value is not None and not isinstance(value, bool)
+        ]
+
+        if invalid_keys:
+            raise InvalidConfiguration(
+                f"Invalid values for keys: "
+                f"{', '.join(invalid_keys)}. Expected booleans."
+            )
+
+    @staticmethod
+    def _resolve_cli_config_settings(setting_name, cli_setting, cfg_setting):
+        if cli_setting is not None:
+            if cfg_setting is not None and cli_setting != cfg_setting:
+                click.echo(
+                    f"Value of '{setting_name}' from CLI : {cli_setting}. "
+                    f"This will override push={cfg_setting} "
+                    f"as configured in pyproject.toml"
+                )
+            return cli_setting
+        return cfg_setting if cfg_setting is not None else True
+
+    @staticmethod
+    def _generate_overriding_error(key, cli_value, cfg_value):
+        return (
+            f"Value of '{key}' from CLI: {cli_value}. This will override "
+            f"{key}={cfg_value} as configured in pyproject.toml"
+        )
+
+    @staticmethod
+    def _resolve_version_configuration(data, cli_args):
+        """
+        Function to return tag and push from
+        pyproject.toml if provided by user.
+        Example file:
+        [tool.pkgmt]
+        github = "repository/package"
+        version = {version_file = "/app/_version.py", tag=True, push=False}
+        """
+
+        if cli_args is None:
+            cli_args = {}
+
+        cfg_version = data.get("version", {})
+        cfg_tag = cfg_version.get("tag", None)
+        cfg_push = cfg_version.get("push", None)
+
+        tag = cli_args.get("tag") if cli_args.get("tag") is not None else cfg_tag
+        push = cli_args.get("push") if cli_args.get("push") is not None else cfg_push
+
+        keys_to_validate = ["tag", "push"]
+        values_to_validate = [tag, push]
+
+        Config._validate_boolean_key(keys_to_validate, values_to_validate)
+
+        conflicts = []
+        if cfg_tag is not None and tag != cfg_tag:
+            conflicts.append(Config._generate_overriding_error("tag", tag, cfg_tag))
+        if cfg_push is not None and push != cfg_push:
+            conflicts.append(Config._generate_overriding_error("push", push, cfg_push))
+
+        if conflicts:
+            click.echo("\n".join(conflicts))
+
+        tag = tag if tag is not None else True
+        push = push if push is not None else True
+
+        version = {"tag": tag, "push": push}
+        data.setdefault("version", {}).update(version)
+        return data
+
+    @classmethod
+    def from_file(cls, file, **kwargs):
+        if Path(file).exists():
             try:
-                with open("pyproject.toml") as f:
-                    self.cfg = Config(toml.load(f)["tool"]["pkgmt"], "pyproject.toml")
-                    self.validate_config()
+                with open(file) as f:
+                    data = toml.load(f)["tool"]["pkgmt"]
+                    Config._validate_config(data)
+                    data = Config._resolve_version_configuration(
+                        data, kwargs.get("cli_args")
+                    )
+                    return cls(data, "pyproject.toml")
             except toml.decoder.TomlDecodeError as e:
                 raise InvalidConfiguration(
                     f"Invalid pyproject.toml file: {str(e)}."
@@ -48,53 +165,3 @@ class PyprojectConfig:
             raise FileNotFoundError(
                 "Could not load configuration file: expected a pyproject.toml file"
             )
-
-    def get_config(self):
-        return self.cfg
-
-    def validate_config(self):
-        """
-        Function to validate top level and version keys in
-        config file.
-        """
-        keys = list(self.cfg.keys())
-        for key in keys:
-            if key not in VALID_KEYS:
-                raise InvalidConfiguration(
-                    f"Invalid key '{key}' in"
-                    f" pyproject.toml file. Valid keys are : "
-                    f"{', '.join(VALID_KEYS)}"
-                )
-
-            if self.cfg.get("version", {}):
-                version_keys = list(self.cfg.get("version").keys())
-                for key in version_keys:
-                    if key not in VALID_VERSION_KEYS:
-                        raise InvalidConfiguration(
-                            f"Invalid version key '{key}' in"
-                            f" pyproject.toml file. Valid keys are : "
-                            f"{', '.join(VALID_VERSION_KEYS)}"
-                        )
-
-    def get_version_configurations(self):
-        """
-        Function to return tag and push from
-        pyproject.toml if provided by user.
-        Example file:
-        [tool.pkgmt]
-        github = "repository/package"
-        version = {version_file = "/app/_version.py", tag=True, push=False}
-        """
-        tag = self.cfg.get("version", {}).get("tag", None)
-        push = self.cfg.get("version", {}).get("push", None)
-        if tag is not None and not isinstance(tag, bool):
-            raise InvalidConfiguration(
-                "Type of 'tag' key in pyproject.toml is invalid. "
-                "It should be lowercase boolean : true / false"
-            )
-        if push is not None and not isinstance(push, bool):
-            raise InvalidConfiguration(
-                "Type of 'push' key in pyproject.toml is invalid. "
-                "It should be lowercase boolean : true / false"
-            )
-        return tag, push

--- a/src/pkgmt/config.py
+++ b/src/pkgmt/config.py
@@ -80,20 +80,8 @@ class Config(Mapping):
         if invalid_keys:
             raise InvalidConfiguration(
                 f"Invalid values for keys: "
-                f"{', '.join(invalid_keys)}. Expected booleans."
+                f"{', '.join(invalid_keys)}. Expected boolean."
             )
-
-    @staticmethod
-    def _resolve_cli_config_settings(setting_name, cli_setting, cfg_setting):
-        if cli_setting is not None:
-            if cfg_setting is not None and cli_setting != cfg_setting:
-                click.echo(
-                    f"Value of '{setting_name}' from CLI : {cli_setting}. "
-                    f"This will override push={cfg_setting} "
-                    f"as configured in pyproject.toml"
-                )
-            return cli_setting
-        return cfg_setting if cfg_setting is not None else True
 
     @staticmethod
     def _generate_overriding_error(key, cli_value, cfg_value):

--- a/src/pkgmt/config.py
+++ b/src/pkgmt/config.py
@@ -33,7 +33,7 @@ def load():
                 return Config(toml.load(f)["tool"]["pkgmt"], "pyproject.toml")
         except toml.decoder.TomlDecodeError as e:
             raise ValueError(
-                f"Invalid pyproject.toml file: {e}."
+                f"Invalid pyproject.toml file: {str(e)}."
                 "If using a boolean "
                 "value ensure it's in lowercase, e.g., key = true"
             )

--- a/src/pkgmt/config.py
+++ b/src/pkgmt/config.py
@@ -30,69 +30,71 @@ class Config(Mapping):
         return f"{type(self).__name__}({self._data!r})"
 
 
-def validate_config(cfg):
-    """
-    Function to validate top level and version keys in
-    config file.
-    """
-    keys = list(cfg.keys())
-    for key in keys:
-        if key not in VALID_KEYS:
-            raise InvalidConfiguration(
-                f"Invalid key '{key}' in"
-                f" pyproject.toml file. Valid keys are : "
-                f"{', '.join(VALID_KEYS)}"
+class PyprojectConfig:
+    def __init__(self):
+        self.cfg = None
+        if Path("pyproject.toml").exists():
+            try:
+                with open("pyproject.toml") as f:
+                    self.cfg = Config(toml.load(f)["tool"]["pkgmt"], "pyproject.toml")
+                    self.validate_config()
+            except toml.decoder.TomlDecodeError as e:
+                raise InvalidConfiguration(
+                    f"Invalid pyproject.toml file: {str(e)}."
+                    "If using a boolean "
+                    "value ensure it's in lowercase, e.g., key = true"
+                )
+        else:
+            raise FileNotFoundError(
+                "Could not load configuration file: expected a pyproject.toml file"
             )
 
-        if cfg.get("version", {}):
-            version_keys = list(cfg.get("version").keys())
-            for key in version_keys:
-                if key not in VALID_VERSION_KEYS:
-                    raise InvalidConfiguration(
-                        f"Invalid version key '{key}' in"
-                        f" pyproject.toml file. Valid keys are : "
-                        f"{', '.join(VALID_VERSION_KEYS)}"
-                    )
+    def get_config(self):
+        return self.cfg
 
+    def validate_config(self):
+        """
+        Function to validate top level and version keys in
+        config file.
+        """
+        keys = list(self.cfg.keys())
+        for key in keys:
+            if key not in VALID_KEYS:
+                raise InvalidConfiguration(
+                    f"Invalid key '{key}' in"
+                    f" pyproject.toml file. Valid keys are : "
+                    f"{', '.join(VALID_KEYS)}"
+                )
 
-def read_version_configurations(cfg):
-    """
-    Function to return tag and push from
-    pyproject.toml if provided by user.
-    Example file:
-    [tool.pkgmt]
-    github = "repository/package"
-    version = {version_file = "/app/_version.py", tag=True, push=False}
-    """
-    tag = cfg.get("version", {}).get("tag", None)
-    push = cfg.get("version", {}).get("push", None)
-    if tag is not None and not isinstance(tag, bool):
-        raise InvalidConfiguration(
-            "Type of 'tag' key in pyproject.toml is invalid. "
-            "It should be lowercase boolean : true / false"
-        )
-    if push is not None and not isinstance(push, bool):
-        raise InvalidConfiguration(
-            "Type of 'push' key in pyproject.toml is invalid. "
-            "It should be lowercase boolean : true / false"
-        )
-    return tag, push
+            if self.cfg.get("version", {}):
+                version_keys = list(self.cfg.get("version").keys())
+                for key in version_keys:
+                    if key not in VALID_VERSION_KEYS:
+                        raise InvalidConfiguration(
+                            f"Invalid version key '{key}' in"
+                            f" pyproject.toml file. Valid keys are : "
+                            f"{', '.join(VALID_VERSION_KEYS)}"
+                        )
 
-
-def load():
-    if Path("pyproject.toml").exists():
-        try:
-            with open("pyproject.toml") as f:
-                cfg = Config(toml.load(f)["tool"]["pkgmt"], "pyproject.toml")
-                validate_config(cfg)
-                return cfg
-        except toml.decoder.TomlDecodeError as e:
+    def get_version_configurations(self):
+        """
+        Function to return tag and push from
+        pyproject.toml if provided by user.
+        Example file:
+        [tool.pkgmt]
+        github = "repository/package"
+        version = {version_file = "/app/_version.py", tag=True, push=False}
+        """
+        tag = self.cfg.get("version", {}).get("tag", None)
+        push = self.cfg.get("version", {}).get("push", None)
+        if tag is not None and not isinstance(tag, bool):
             raise InvalidConfiguration(
-                f"Invalid pyproject.toml file: {str(e)}."
-                "If using a boolean "
-                "value ensure it's in lowercase, e.g., key = true"
+                "Type of 'tag' key in pyproject.toml is invalid. "
+                "It should be lowercase boolean : true / false"
             )
-    else:
-        raise FileNotFoundError(
-            "Could not load configuration file: expected a pyproject.toml file"
-        )
+        if push is not None and not isinstance(push, bool):
+            raise InvalidConfiguration(
+                "Type of 'push' key in pyproject.toml is invalid. "
+                "It should be lowercase boolean : true / false"
+            )
+        return tag, push

--- a/src/pkgmt/config.py
+++ b/src/pkgmt/config.py
@@ -43,7 +43,7 @@ class PyprojectConfig:
                     f"Invalid pyproject.toml file: {str(e)}."
                     "If using a boolean "
                     "value ensure it's in lowercase, e.g., key = true"
-                )
+                ) from e
         else:
             raise FileNotFoundError(
                 "Could not load configuration file: expected a pyproject.toml file"

--- a/src/pkgmt/dev.py
+++ b/src/pkgmt/dev.py
@@ -7,7 +7,7 @@ import shutil
 from pathlib import Path
 
 from invoke import task
-from pkgmt.config import load
+from pkgmt.config import PyprojectConfig
 
 community = "https://ploomber.io/community"
 
@@ -43,7 +43,7 @@ def setup(c, version=None, doc=False):
     if not shutil.which("conda"):
         raise CommandError("conda not installed. Install it an try again.")
 
-    cfg = load()
+    cfg = PyprojectConfig().get_config()
 
     env_prefix = cfg.get("env_name", cfg["package_name"])
     pkg_name = cfg["package_name"]

--- a/src/pkgmt/dev.py
+++ b/src/pkgmt/dev.py
@@ -43,7 +43,7 @@ def setup(c, version=None, doc=False):
     if not shutil.which("conda"):
         raise CommandError("conda not installed. Install it an try again.")
 
-    cfg = Config().from_file("pyproject.toml")
+    cfg = Config.from_file("pyproject.toml")
 
     env_prefix = cfg.get("env_name", cfg["package_name"])
     pkg_name = cfg["package_name"]

--- a/src/pkgmt/dev.py
+++ b/src/pkgmt/dev.py
@@ -7,7 +7,7 @@ import shutil
 from pathlib import Path
 
 from invoke import task
-from pkgmt.config import PyprojectConfig
+from pkgmt.config import Config
 
 community = "https://ploomber.io/community"
 
@@ -43,7 +43,7 @@ def setup(c, version=None, doc=False):
     if not shutil.which("conda"):
         raise CommandError("conda not installed. Install it an try again.")
 
-    cfg = PyprojectConfig().get_config()
+    cfg = Config().from_file("pyproject.toml")
 
     env_prefix = cfg.get("env_name", cfg["package_name"])
     pkg_name = cfg["package_name"]

--- a/src/pkgmt/exceptions.py
+++ b/src/pkgmt/exceptions.py
@@ -7,3 +7,9 @@ class ProjectValidationError(ClickException):
     """
 
     pass
+
+
+class InvalidConfiguration(ClickException):
+    """
+    Raised when invalid pyproject.toml file
+    """

--- a/src/pkgmt/versioneer.py
+++ b/src/pkgmt/versioneer.py
@@ -123,9 +123,9 @@ def read_version_config(cfg):
             "Type of 'push' key in pyproject.toml is invalid. "
             "It should be lowercase boolean : true / false"
         )
-    if tag:
+    if tag is not None:
         print(f"Reading tag = {tag} from pyproject.toml")
-    if push:
+    if push is not None:
         print(f"Reading push = {push} from pyproject.toml")
     return tag, push
 

--- a/src/pkgmt/versioneer.py
+++ b/src/pkgmt/versioneer.py
@@ -7,15 +7,10 @@ import subprocess
 from pathlib import Path
 import click
 
-from pkgmt.config import load
 from pkgmt.changelog import expand_github_from_changelog, CHANGELOG
 from pkgmt.versioner.versioner import Versioner
 from pkgmt.versioner.util import complete_version_string, is_pre_release
 from pkgmt.deprecation import Deprecations
-
-
-VALID_KEYS = ["github", "version", "package_name"]
-VALID_VERSION_KEYS = ["version_file", "tag", "push"]
 
 
 def replace_in_file(path_to_file, original, replacement):
@@ -77,59 +72,6 @@ def validate_version_string(version):
     return complete_version_string(version)
 
 
-def validate_config(cfg):
-    """
-    Function to validate top level and version keys in
-    config file.
-    """
-    keys = list(cfg.keys())
-    for key in keys:
-        if key not in VALID_KEYS:
-            raise click.ClickException(
-                f"Invalid key '{key}' in"
-                f" pyproject.toml file. Valid keys are : "
-                f"{', '.join(VALID_KEYS)}"
-            )
-
-        if cfg.get("version", {}):
-            version_keys = list(cfg.get("version").keys())
-            for key in version_keys:
-                if key not in VALID_VERSION_KEYS:
-                    raise click.ClickException(
-                        f"Invalid version key '{key}' in"
-                        f" pyproject.toml file. Valid keys are : "
-                        f"{', '.join(VALID_VERSION_KEYS)}"
-                    )
-
-
-def read_version_config(cfg):
-    """
-    Function to return tag and push from
-    pyproject.toml if provided by user.
-    Example file:
-    [tool.pkgmt]
-    github = "repository/package"
-    version = {version_file = "/app/_version.py", tag=True, push=False}
-    """
-    tag = cfg.get("version", {}).get("tag", None)
-    push = cfg.get("version", {}).get("push", None)
-    if tag is not None and not isinstance(tag, bool):
-        raise click.ClickException(
-            "Type of 'tag' key in pyproject.toml is invalid. "
-            "It should be lowercase boolean : true / false"
-        )
-    if push is not None and not isinstance(push, bool):
-        raise click.ClickException(
-            "Type of 'push' key in pyproject.toml is invalid. "
-            "It should be lowercase boolean : true / false"
-        )
-    if tag is not None:
-        print(f"Reading tag = {tag} from pyproject.toml")
-    if push is not None:
-        print(f"Reading push = {push} from pyproject.toml")
-    return tag, push
-
-
 def version(
     project_root=".",
     tag=True,
@@ -170,14 +112,6 @@ def version(
             "Commit them or discard them and try again.\nDetected files:"
             f"\n{pending.decode()}"
         )
-
-    cfg = load()
-
-    validate_config(cfg)
-
-    cfg_tag, cfg_push = read_version_config(cfg)
-    tag = cfg_tag if cfg_tag is not None else tag
-    push = cfg_push if cfg_push is not None else push
 
     versioner = Versioner(project_root)
 

--- a/src/pkgmt/versioneer.py
+++ b/src/pkgmt/versioneer.py
@@ -7,10 +7,15 @@ import subprocess
 from pathlib import Path
 import click
 
+from pkgmt.config import load
 from pkgmt.changelog import expand_github_from_changelog, CHANGELOG
 from pkgmt.versioner.versioner import Versioner
 from pkgmt.versioner.util import complete_version_string, is_pre_release
 from pkgmt.deprecation import Deprecations
+
+
+VALID_KEYS = ["github", "version", "package_name"]
+VALID_VERSION_KEYS = ["version_file", "tag", "push"]
 
 
 def replace_in_file(path_to_file, original, replacement):
@@ -72,6 +77,59 @@ def validate_version_string(version):
     return complete_version_string(version)
 
 
+def validate_config(cfg):
+    """
+    Function to validate top level and version keys in
+    config file.
+    """
+    keys = list(cfg.keys())
+    for key in keys:
+        if key not in VALID_KEYS:
+            raise click.ClickException(
+                f"Invalid key '{key}' in"
+                f" pyproject.toml file. Valid keys are : "
+                f"{', '.join(VALID_KEYS)}"
+            )
+
+        if cfg.get("version", {}):
+            version_keys = list(cfg.get("version").keys())
+            for key in version_keys:
+                if key not in VALID_VERSION_KEYS:
+                    raise click.ClickException(
+                        f"Invalid version key '{key}' in"
+                        f" pyproject.toml file. Valid keys are : "
+                        f"{', '.join(VALID_VERSION_KEYS)}"
+                    )
+
+
+def read_version_config(cfg):
+    """
+    Function to return tag and push from
+    pyproject.toml if provided by user.
+    Example file:
+    [tool.pkgmt]
+    github = "repository/package"
+    version = {version_file = "/app/_version.py", tag=True, push=False}
+    """
+    tag = cfg.get("version", {}).get("tag", None)
+    push = cfg.get("version", {}).get("push", None)
+    if tag is not None and not isinstance(tag, bool):
+        raise click.ClickException(
+            "Type of 'tag' key in pyproject.toml is invalid. "
+            "It should be lowercase boolean : true / false"
+        )
+    if push is not None and not isinstance(push, bool):
+        raise click.ClickException(
+            "Type of 'push' key in pyproject.toml is invalid. "
+            "It should be lowercase boolean : true / false"
+        )
+    if tag:
+        print(f"Reading tag = {tag} from pyproject.toml")
+    if push:
+        print(f"Reading push = {push} from pyproject.toml")
+    return tag, push
+
+
 def version(
     project_root=".",
     tag=True,
@@ -112,6 +170,14 @@ def version(
             "Commit them or discard them and try again.\nDetected files:"
             f"\n{pending.decode()}"
         )
+
+    cfg = load()
+
+    validate_config(cfg)
+
+    cfg_tag, cfg_push = read_version_config(cfg)
+    tag = cfg_tag if cfg_tag is not None else tag
+    push = cfg_push if cfg_push is not None else push
 
     versioner = Versioner(project_root)
 

--- a/src/pkgmt/versioner/util.py
+++ b/src/pkgmt/versioner/util.py
@@ -3,7 +3,7 @@ import os
 import click
 import warnings
 from pathlib import Path
-from pkgmt.config import load
+from pkgmt.config import PyprojectConfig
 
 
 def is_pre_release(version):
@@ -138,7 +138,7 @@ def find_package_and_version_file(project_root="."):
     Else version file in __init__.py found in the first package
     inside src directory.
     """
-    cfg = load()
+    cfg = PyprojectConfig().get_config()
     version_file = cfg.get("version", {}).get("version_file", None)
     validate_version_file(version_file)
     if version_file:

--- a/src/pkgmt/versioner/util.py
+++ b/src/pkgmt/versioner/util.py
@@ -3,7 +3,7 @@ import os
 import click
 import warnings
 from pathlib import Path
-from pkgmt.config import PyprojectConfig
+from pkgmt.config import Config
 
 
 def is_pre_release(version):
@@ -138,7 +138,7 @@ def find_package_and_version_file(project_root="."):
     Else version file in __init__.py found in the first package
     inside src directory.
     """
-    cfg = PyprojectConfig().get_config()
+    cfg = Config.from_file("pyproject.toml")
     version_file = cfg.get("version", {}).get("version_file", None)
     validate_version_file(version_file)
     if version_file:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -179,3 +179,86 @@ def test_lint_black_pyproj(pyproject, command, output, tmp_empty):
     result = runner.invoke(cli.cli, command)
 
     assert output in result.output
+
+
+@pytest.mark.parametrize(
+    "args, push, tag, pyproject, message",
+    [
+        [
+            ["version"],
+            True,
+            False,
+            '[tool.pkgmt]\ngithub = "edublancas/pkgmt"\n\n[tool.pkgmt.version]\n'
+            'version_file = "/app/_version.py"\ntag = false',
+            "",
+        ],
+        [
+            ["version"],
+            False,
+            True,
+            '[tool.pkgmt]\ngithub = "edublancas/pkgmt"\n\n[tool.pkgmt.version]\n'
+            'version_file = "/app/_version.py"\npush = false',
+            "",
+        ],
+        [
+            ["version"],
+            False,
+            False,
+            '[tool.pkgmt]\ngithub = "edublancas/pkgmt"\n\n[tool.pkgmt.version]\n'
+            'version_file = "/app/_version.py"\npush = false\ntag = false',
+            "",
+        ],
+        [
+            ["version", "--push"],
+            True,
+            False,
+            '[tool.pkgmt]\ngithub = "edublancas/pkgmt"\n\n[tool.pkgmt.version]\n'
+            'version_file = "/app/_version.py"\npush = false\ntag = false',
+            "Value of 'push' from CLI : True. This will override push=False "
+            "as configured in pyproject.toml",
+        ],
+        [
+            ["version", "--no-push"],
+            False,
+            False,
+            '[tool.pkgmt]\ngithub = "edublancas/pkgmt"\n\n[tool.pkgmt.version]\n'
+            'version_file = "/app/_version.py"\npush = true\ntag = false',
+            "Value of 'push' from CLI : False. This will override push=True "
+            "as configured in pyproject.toml",
+        ],
+        [
+            ["version", "--tag"],
+            True,
+            True,
+            '[tool.pkgmt]\ngithub = "edublancas/pkgmt"\n\n[tool.pkgmt.version]\n'
+            'version_file = "/app/_version.py"\npush = true\ntag = false',
+            "Value of 'tag' from CLI : True. This will override tag=False "
+            "as configured in pyproject.toml",
+        ],
+        [
+            ["version", "--no-tag"],
+            True,
+            False,
+            '[tool.pkgmt]\ngithub = "edublancas/pkgmt"\n\n[tool.pkgmt.version]\n'
+            'version_file = "/app/_version.py"\npush = true\ntag = true',
+            "Value of 'tag' from CLI : False. This will override tag=True "
+            "as configured in pyproject.toml",
+        ],
+    ],
+)
+def test_tag_push_config(
+    tmp_another_package, monkeypatch, args, push, tag, pyproject, message
+):
+    Path("pyproject.toml").unlink()
+    Path("pyproject.toml").write_text(pyproject)
+    mock = Mock()
+
+    monkeypatch.setattr(cli.versioneer, "version", mock)
+    runner = CliRunner()
+    result = runner.invoke(cli.cli, args)
+
+    mock.assert_called_once_with(
+        project_root=".", tag=tag, yes=False, push=push, target=None
+    )
+    assert result.exit_code == 0
+    assert message in result.output

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,7 +6,7 @@ from pkgmt import config
 
 @pytest.fixture
 def toml_cfg(tmp_empty):
-    cfg_ = {"github": "edublancas/pkgmt"}
+    cfg_ = {"github": "edublancas/pkgmt", "version": {"tag": True, "push": True}}
     cfg = {"tool": {"pkgmt": cfg_}}
 
     with open("pyproject.toml", "w") as f:
@@ -16,21 +16,21 @@ def toml_cfg(tmp_empty):
 
 
 def test_load_toml(toml_cfg):
-    loaded = config.PyprojectConfig().get_config()
+    loaded = config.Config.from_file("pyproject.toml")
 
     assert loaded == toml_cfg
 
 
 def test_missing_file(tmp_empty):
     with pytest.raises(FileNotFoundError) as excinfo:
-        config.PyprojectConfig()
+        config.Config.from_file("pyproject.toml")
     assert "Could not load configuration file: expected a pyproject.toml file" in str(
         excinfo.value
     )
 
 
 def test_key_error(toml_cfg):
-    cfg = config.PyprojectConfig().get_config()
+    cfg = config.Config.from_file("pyproject.toml")
 
     with pytest.raises(KeyError) as excinfo:
         cfg["some_key"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,21 +16,21 @@ def toml_cfg(tmp_empty):
 
 
 def test_load_toml(toml_cfg):
-    loaded = config.load()
+    loaded = config.PyprojectConfig().get_config()
 
     assert loaded == toml_cfg
 
 
 def test_missing_file(tmp_empty):
     with pytest.raises(FileNotFoundError) as excinfo:
-        config.load()
+        config.PyprojectConfig()
     assert "Could not load configuration file: expected a pyproject.toml file" in str(
         excinfo.value
     )
 
 
 def test_key_error(toml_cfg):
-    cfg = config.load()
+    cfg = config.PyprojectConfig().get_config()
 
     with pytest.raises(KeyError) as excinfo:
         cfg["some_key"]

--- a/tests/test_versioneer.py
+++ b/tests/test_versioneer.py
@@ -1150,7 +1150,7 @@ def test_version_key_missing_value(
 )
 def test_validate_config(config, error):
     with pytest.raises(click.ClickException) as excinfo:
-        versioneer.validate_config(config)
+        config.validate_config(config)
     assert error in str(excinfo.value)
 
 


### PR DESCRIPTION
1. Validation of top level and `version` level keys in `pyproject.toml` file
2. Supporting `tag` and `push` parameters through `pyproject.toml`

Closes #65 #63

Acceptance criteria for #65:
1. Validate keys in pyproject.toml file and raise error if any invalid key found. Display all the valid keys to user.
2. Test cases for the same
3. Changelog entry.

Acceptance criteria for #63 
1. Add support for tag and push keys.
2. Validation of keys and throw error if any invalid key found.
3. Test cases
4. Changelog entry.