### PR TITLE
add --version to pkgmt setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## 0.7.5dev
+* [Feature] Added `--version` option to `pkgmt setup` to specify Python version
 
 ## 0.7.4 (2023-09-08)
 

--- a/src/pkgmt/cli.py
+++ b/src/pkgmt/cli.py
@@ -138,7 +138,13 @@ def release(tag, production, yes):
     default=False,
     help="Install documentation dependencies",
 )
-def setup(doc):
+@click.option(
+    "--version",
+    default=None,
+    type=str,
+    help="Select a Python version, default is 3.10" "Eg: --version 3.9",
+)
+def setup(version, doc):
     """Setup development environment
 
     Create conda environment and install dependencies:
@@ -150,7 +156,7 @@ def setup(doc):
         $ pkgmt setup --doc
     """
     try:
-        dev.setup(Context(), doc=doc)
+        dev.setup(Context(), version=version, doc=doc)
     except UnexpectedExit as e:
         raise SystemExit(f"Error running: {e.result.command}") from e
 

--- a/src/pkgmt/cli.py
+++ b/src/pkgmt/cli.py
@@ -142,7 +142,7 @@ def release(tag, production, yes):
     "--version",
     default=None,
     type=str,
-    help="Select a Python version, default is 3.10" "Eg: --version 3.9",
+    help="Select a Python version, default is 3.10",
 )
 def setup(version, doc):
     """Setup development environment

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ from click.testing import CliRunner
 import pytest
 
 from pkgmt import cli
+from invoke import Context
 
 
 @pytest.mark.parametrize(
@@ -262,3 +263,33 @@ def test_lint_black_pyproj(pyproject, command, output, tmp_empty):
     result = runner.invoke(cli.cli, command)
 
     assert output in result.output
+
+
+@pytest.mark.parametrize(
+    "command, version, doc",
+    [
+        [
+            ["setup"],
+            None,
+            False,
+        ],
+        [
+            ["setup", "--version", "3.9"],
+            "3.9",
+            False,
+        ],
+        [
+            ["setup", "--version", "3.9", "--doc"],
+            "3.9",
+            True,
+        ],
+    ],
+)
+def test_setup_with_python_version(monkeypatch, command, version, doc):
+    mock = Mock()
+    monkeypatch.setattr(cli.dev, "setup", mock)
+
+    runner = CliRunner()
+    runner.invoke(cli.cli, command)
+
+    mock.assert_called_once_with(Context(), version=version, doc=doc)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -268,21 +268,14 @@ def test_lint_black_pyproj(pyproject, command, output, tmp_empty):
 @pytest.mark.parametrize(
     "command, version, doc",
     [
-        [
-            ["setup"],
-            None,
-            False,
-        ],
-        [
-            ["setup", "--version", "3.9"],
-            "3.9",
-            False,
-        ],
-        [
-            ["setup", "--version", "3.9", "--doc"],
-            "3.9",
-            True,
-        ],
+        [["setup"], None, False],
+        [["setup", "--version", "2.7"], "2.7", False],
+        [["setup", "--version", "3.7"], "3.7", False],
+        [["setup", "--version", "3.8"], "3.8", False],
+        [["setup", "--version", "3.9"], "3.9", False],
+        [["setup", "--version", "3.10"], "3.10", False],
+        [["setup", "--version", "3.11"], "3.11", False],
+        [["setup", "--version", "3.9", "--doc"], "3.9", True],
     ],
 )
 def test_setup_with_python_version(monkeypatch, command, version, doc):


### PR DESCRIPTION
Changes:
- Modified pkgmt setup to include a "--version" flag

Closes #72 

Checklist before requesting a review
- [x] Performed a self-review of my code
- [x] Formatted my code with [pkgmt format](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)
- [x] Added tests