### PR TITLE
Use python 3.11 when checking project in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
https://github.com/ploomber/pkgmt/commit/e1800ebc625daad829458b5abd38aca5fa658cd0 appears that the 3.10 version should be outdated for pkgmt. Maybe we should use 3.11 instead.

Feel free to close this MR 😄